### PR TITLE
fix for no CFBundleName in Info.plist

### DIFF
--- a/quickpkg
+++ b/quickpkg
@@ -158,6 +158,8 @@ def appNameAndVersion(app_path):
         cleanup_and_exit(1)
     info_plist = plistlib.readPlist(info_path)
     app_name = info_plist.get("CFBundleName", None)
+    if app_name is None:
+        app_name = info_plist.get("CFBundleExecutable", None)
     app_identifier = info_plist.get("CFBundleIdentifier", None)
     app_version = info_plist.get("CFBundleShortVersionString", None)
     if app_version is None:


### PR DESCRIPTION
[Pashua](https://www.bluem.net/en/mac/pashua/) the first app I attempted to repackage does not have CFBundleName set in Info.plist.

Compare the result here:

```
ryan at ATEC-MBP-RMANLY: ~/src/quickpkg on master
$ ./quickpkg ~/Downloads/Pashua.dmg
None-0.10.3.pkg
```

vs:

```
ryan at ATEC-MBP-RMANLY: ~/src/forks/quickpkg on no_name [!]
$ ./quickpkg /Users/ryan/Downloads/Pashua.dmg
Pashua-0.10.3.pkg
```

I do not know how common this problem is but several apps I inspected on my system CFBundleExecutable == CFBundleName so this will attempt to assign that as well. Similar to versions a few lines below.