### PR TITLE
Provide useful error and exit gracefully if app has no usable version

### DIFF
--- a/quickpkg
+++ b/quickpkg
@@ -171,6 +171,13 @@ def appNameAndVersion(app_path):
     app_version = info_plist.get("CFBundleShortVersionString")
     if app_version is None or app_version == "":
         app_version = info_plist.get("CFBundleVersion")
+    if app_version is None or app_version == "":
+        print(
+            "Application at path %s does not have a "
+            "CFBundleShortVersionString or CFBundleVersion" % app_path
+        )
+        # TODO: cleanup volumes here
+        cleanup_and_exit(1)
     return (app_name, app_identifier, app_version)
 
 


### PR DESCRIPTION
I recently came across an app without either a `CFBundleShortVersionString` or `CFBundleVersion` key in its Info.plist file. Quickpkg understandably failed to package the app, but the provided traceback didn't make it obvious to me what the problem was.

```
% ./quickpkg ~/Desktop/PCoIPClient.app             
Traceback (most recent call last):
  File "./quickpkg", line 427, in <module>
    result = cmdexec(analyzecmd)
  File "./quickpkg", line 35, in cmdexec
    proc = subprocess.Popen(
  File "/Library/ManagedFrameworks/Python/Python3.framework/Versions/3.9/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/Library/ManagedFrameworks/Python/Python3.framework/Versions/3.9/lib/python3.9/subprocess.py", line 1754, in _execute_child
    self.pid = _posixsubprocess.fork_exec(
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

This pull request adds an exit condition if no usable version key is found that should eliminate this confusion if anybody encounters the same problem I did.

```
% ./quickpkg ~/Desktop/PCoIPClient.app                                         
Application at path /var/folders/0n/svv6yz7d5qlf59695s39bnx40000gn/T/tmpu2zm2dyp/payload/PCoIPClient.app does not have a CFBundleShortVersionString or CFBundleVersion
```
